### PR TITLE
Spanish - Use the same verb

### DIFF
--- a/data/es/choices.js
+++ b/data/es/choices.js
@@ -1,12 +1,12 @@
 module.exports = {
   plus: [
     {
-      text: 'Muy Impreciso',
+      text: 'Muy en desacuerdo',
       score: 1,
       color: 1
     },
     {
-      text: 'Moderadamente Impreciso',
+      text: 'Moderadamente en desacuerdo',
       score: 2,
       color: 2
     },
@@ -28,12 +28,12 @@ module.exports = {
   ],
   minus: [
     {
-      text: 'Muy Impreciso',
+      text: 'Muy en desacuerdo',
       score: 5,
       color: 1
     },
     {
-      text: 'Moderadamente Impreciso',
+      text: 'Moderadamente en desacuerdo',
       score: 4,
       color: 2
     },


### PR DESCRIPTION
The current translation is confusing as it mixes two verbs:
"Impreciso" - "Imprecise"
"Ni de acuerdo ni en desacuerdo" - "Don't agree nor disagree"
"De acuerdo" - "Agree"

This pull request suggests replacing "impreciso" with "en desacuerdo" ("disagree") to give the choices a continuity between them. Using "agree" rather than "precise" was chosen because of it's more widespread usage.