### PR TITLE
Add Bengali (bn) translation

### DIFF
--- a/data/bn/choices.js
+++ b/data/bn/choices.js
@@ -1,0 +1,56 @@
+module.exports = {
+  plus: [
+    {
+      text: 'খুবই ভুল',
+      score: 1,
+      color: 1
+    },
+    {
+      text: 'মোটামুটি ভুল',
+      score: 2,
+      color: 2
+    },
+    {
+      text: 'ঠিক বা ভুল কোনোটাই নয়',
+      score: 3,
+      color: 3
+    },
+    {
+      text: 'মোটামুটি ঠিক',
+      score: 4,
+      color: 4
+    },
+    {
+      text: 'খুবই ঠিক',
+      score: 5,
+      color: 5
+    }
+  ],
+  minus: [
+    {
+      text: 'খুবই ভুল',
+      score: 5,
+      color: 1
+    },
+    {
+      text: 'মোটামুটি ভুল',
+      score: 4,
+      color: 2
+    },
+    {
+      text: 'ঠিক বা ভুল কোনোটাই নয়',
+      score: 3,
+      color: 3
+    },
+    {
+      text: 'মোটামুটি ঠিক',
+      score: 2,
+      color: 4
+    },
+    {
+      text: 'খুবই ঠিক',
+      score: 1,
+      color: 5
+    }
+  ]
+}

--- a/data/bn/questions.json
+++ b/data/bn/questions.json
@@ -1,0 +1,842 @@
+[
+  {
+    "id": "43c98ce8-a07a-4dc2-80f6-c1b2a2485f06",
+    "text": "বিভিন্ন বিষয় নিয়ে দুশ্চিন্তা করি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 1
+  },
+  {
+    "id": "d50a597f-632b-4f7b-89e6-6d85b50fd1c9",
+    "text": "সহজে বন্ধুত্ব করতে পারি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 1
+  },
+  {
+    "id": "888dd864-7449-4e96-8d5c-7a439603ea91",
+    "text": "আমার কল্পনাশক্তি প্রখর",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 1
+  },
+  {
+    "id": "ce2fbbf8-7a97-4199-bda5-117e4ecdf3b6",
+    "text": "অন্যদের বিশ্বাস করি",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 1
+  },
+  {
+    "id": "c7f53c3c-2e77-432f-bb71-7470b67d3aa9",
+    "text": "কাজ সফলভাবে সম্পন্ন করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 1
+  },
+  {
+    "id": "48ad12ce-470e-4339-90ac-ea8c43a0103e",
+    "text": "সহজে রেগে যাই",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 2
+  },
+  {
+    "id": "458f3957-2359-4077-ade1-34525d633063",
+    "text": "বড় পার্টি পছন্দ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 2
+  },
+  {
+    "id": "58d571e5-d725-4cf8-a438-32c16ee28eb6",
+    "text": "মনে করি শিল্পকলা গুরুত্বপূর্ণ",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 2
+  },
+  {
+    "id": "0cf79e27-e702-45c2-9471-04ac96b58e0e",
+    "text": "নিজের স্বার্থে অন্যদের ব্যবহার করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 2
+  },
+  {
+    "id": "cda1ca17-b599-4561-a6cd-ff9d36062d27",
+    "text": "গোছগাছ করতে পছন্দ করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 2
+  },
+  {
+    "id": "5e8550d7-b8ef-4905-950a-f81d735d39e2",
+    "text": "প্রায়ই মনমরা বোধ করি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 3
+  },
+  {
+    "id": "8af754f2-68e9-48f3-8c5d-2e6633d4472c",
+    "text": "নেতৃত্ব নিতে পছন্দ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 3
+  },
+  {
+    "id": "0727def6-3d18-4221-bf38-86b58f9f3eed",
+    "text": "আমার আবেগগুলো তীব্রভাবে অনুভব করি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 3
+  },
+  {
+    "id": "ccf3a5c8-fb50-4bd4-8e7a-22af3d657279",
+    "text": "অন্যদের সাহায্য করতে ভালোবাসি",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 3
+  },
+  {
+    "id": "73d84e5d-cbf5-47f0-b8cb-4d2159a52e32",
+    "text": "আমার প্রতিশ্রুতি রক্ষা করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 3
+  },
+  {
+    "id": "b2d9ef74-73f5-4ea8-b00c-7aaca15937df",
+    "text": "অন্যদের কাছে যেতে আমার অসুবিধা হয়",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 4
+  },
+  {
+    "id": "48a761ef-438e-409b-ae59-ea2ce8f84414",
+    "text": "সবসময় ব্যস্ত থাকি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 4
+  },
+  {
+    "id": "cae55842-8957-4e3b-83b3-ceff98fb9dcf",
+    "text": "একঘেয়ে রুটিনের চেয়ে বৈচিত্র্য পছন্দ করি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 4
+  },
+  {
+    "id": "e2028ad3-b128-4f76-be57-398bfe2aff22",
+    "text": "ঝগড়া করতে ভালোবাসি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 4
+  },
+  {
+    "id": "b7fc949b-02b6-4cb9-a3e2-dbb3d824b55f",
+    "text": "কঠোর পরিশ্রম করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 4
+  },
+  {
+    "id": "481efd08-c810-43b1-a952-f8ac9052f96b",
+    "text": "মাঝে মাঝে সংযমহীনভাবে ভোগবিলাসে মেতে উঠি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 5
+  },
+  {
+    "id": "987efee2-899f-4a65-b9b5-1589ef0460d7",
+    "text": "উত্তেজনা পছন্দ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 5
+  },
+  {
+    "id": "e1e804c7-4a1d-498f-8610-f95147af9d1d",
+    "text": "জটিল/চ্যালেঞ্জিং লেখা পড়তে ভালোবাসি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 5
+  },
+  {
+    "id": "71029381-3908-4c68-91e1-e41fb45542a2",
+    "text": "মনে করি আমি অন্যদের চেয়ে ভালো",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 5
+  },
+  {
+    "id": "f6076eea-56ae-4b46-97f1-5f94a7676c96",
+    "text": "সবসময় প্রস্তুত থাকি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 5
+  },
+  {
+    "id": "2f519935-92e8-48ad-9746-4a0f8b38466a",
+    "text": "সহজে আতঙ্কিত হই",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 6
+  },
+  {
+    "id": "899c3f66-51d0-46ea-963a-6fc36d3b3cb9",
+    "text": "চারপাশে আনন্দের আবহ ছড়িয়ে দিই",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 6
+  },
+  {
+    "id": "79186f48-e7fa-4df4-b74b-b0627ee244e1",
+    "text": "সাধারণত উদারপন্থী রাজনৈতিক প্রার্থীদের ভোট দিই",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 6
+  },
+  {
+    "id": "fd50e1ca-d9e0-4037-a7a1-a191d4db2d96",
+    "text": "গৃহহীনদের প্রতি সহানুভূতিশীল",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 6
+  },
+  {
+    "id": "bd9eec0a-b68b-472c-8803-7db29c308cdb",
+    "text": "না ভেবে কাজে ঝাঁপিয়ে পড়ি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 6
+  },
+  {
+    "id": "7f92ab2c-265c-4b84-8c74-09f9bb9d41a7",
+    "text": "সবসময় সবচেয়ে খারাপ কিছু হওয়ার আশঙ্কা করি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 1
+  },
+  {
+    "id": "af55f014-788c-4b6e-92c4-b2b59dc8a28d",
+    "text": "মানুষের আশেপাশে স্বাচ্ছন্দ্য বোধ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 1
+  },
+  {
+    "id": "08ff6dca-02a5-4aeb-aaa4-2ecf2526f143",
+    "text": "উদ্দাম কল্পনাবিলাস উপভোগ করি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 1
+  },
+  {
+    "id": "6f66cdc0-9044-457b-b40d-501ecae15ee7",
+    "text": "মনে করি অন্যদের উদ্দেশ্য ভালো",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 1
+  },
+  {
+    "id": "f110fc66-2e9e-413c-920b-19f05e63d7ac",
+    "text": "যা করি তাতে পারদর্শী হই",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 1
+  },
+  {
+    "id": "7dab2a37-8635-4fc7-86b7-0abf13c183c9",
+    "text": "সহজে বিরক্ত হয়ে যাই",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 2
+  },
+  {
+    "id": "28ab59a0-e7cd-4fce-94e3-bba2ecc023b6",
+    "text": "পার্টিতে অনেক ভিন্ন মানুষের সাথে কথা বলি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 2
+  },
+  {
+    "id": "b5919f2f-cded-4745-a9ce-c02703cee807",
+    "text": "অন্যরা যা লক্ষ্য করে না, তার মধ্যেও সৌন্দর্য দেখতে পাই",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 2
+  },
+  {
+    "id": "5a5fa975-d024-4ac8-8845-2823f957c21b",
+    "text": "এগিয়ে যাওয়ার জন্য প্রতারণা করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 2
+  },
+  {
+    "id": "adf33f9f-45bd-43e3-af25-4c491176d97f",
+    "text": "প্রায়ই জিনিস যথাস্থানে রাখতে ভুলে যাই",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 2
+  },
+  {
+    "id": "f0a14e16-d726-47e9-a2c1-647fd3d7d52e",
+    "text": "নিজেকে অপছন্দ করি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 3
+  },
+  {
+    "id": "0b38e3d3-c15c-454c-b034-f4eb7ae1580a",
+    "text": "অন্যদের নেতৃত্ব দেওয়ার চেষ্টা করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 3
+  },
+  {
+    "id": "5631b856-ff34-4f76-a0cd-edc7104c3bfa",
+    "text": "অন্যদের আবেগ অনুভব করতে পারি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 3
+  },
+  {
+    "id": "ada867af-4db1-4e3d-a604-2b695c1806e5",
+    "text": "অন্যদের নিয়ে যত্নশীল",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 3
+  },
+  {
+    "id": "c55e3958-00c4-4fc3-9118-47d8f31bfde1",
+    "text": "সত্য কথা বলি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 3
+  },
+  {
+    "id": "acd8fadc-5399-4a67-b5ff-9d1ada049c01",
+    "text": "নিজের দিকে মনোযোগ আকর্ষণ করতে ভয় পাই",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 4
+  },
+  {
+    "id": "d07b6c67-0d02-4948-a997-bb84ac234cd8",
+    "text": "সবসময় ছোটাছুটির মধ্যে থাকি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 4
+  },
+  {
+    "id": "33b81fd0-7e32-4cd8-a13a-d5f5f754f998",
+    "text": "যা জানি তা নিয়েই থাকতে পছন্দ করি",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 4
+  },
+  {
+    "id": "d9a9a180-29c9-4ec5-8621-2256d411def7",
+    "text": "মানুষের ওপর চিৎকার করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 4
+  },
+  {
+    "id": "f12c3d9d-1d12-4aa6-ad2e-009cd0651cbb",
+    "text": "যা প্রত্যাশা করা হয় তার চেয়ে বেশি করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 4
+  },
+  {
+    "id": "9891b7ba-a494-4307-aafe-301d8db506c6",
+    "text": "খুব কমই অতিরিক্ত ভোগবিলাসে মাতি",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 5
+  },
+  {
+    "id": "f1675af6-88bf-4376-a946-0281e762b39c",
+    "text": "রোমাঞ্চের সন্ধান করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 5
+  },
+  {
+    "id": "95a3f20c-f933-4d19-a2c1-a7dbdf63c562",
+    "text": "দার্শনিক আলোচনা এড়িয়ে চলি",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 5
+  },
+  {
+    "id": "7df44711-4cd4-4b05-8830-73fcc3ebdab5",
+    "text": "নিজের সম্পর্কে উচ্চ ধারণা পোষণ করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 5
+  },
+  {
+    "id": "9d3cb5c7-955c-43a4-b6c7-b07ed01dcbd9",
+    "text": "আমার পরিকল্পনা বাস্তবায়ন করি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 5
+  },
+  {
+    "id": "13c58810-3864-42ba-aa87-d4166f858756",
+    "text": "ঘটনাবলীর চাপে অভিভূত হয়ে পড়ি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 6
+  },
+  {
+    "id": "961376e0-16a1-4c14-b059-789e63d11b63",
+    "text": "প্রচুর মজা করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 6
+  },
+  {
+    "id": "f08e1b27-3673-4898-9cae-896482d0d9f9",
+    "text": "মনে করি ভালো-মন্দের কোনো চূড়ান্ত মানদণ্ড নেই",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 6
+  },
+  {
+    "id": "c2038c12-7a37-47a8-9983-831bd6692aab",
+    "text": "যারা আমার চেয়ে খারাপ অবস্থায় আছে তাদের প্রতি সহানুভূতি বোধ করি",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 6
+  },
+  {
+    "id": "956f3e17-ff17-4af5-a52f-9222b8968106",
+    "text": "হুট করে সিদ্ধান্ত নিয়ে ফেলি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 6
+  },
+  {
+    "id": "4d81238b-5407-47d4-88e5-dc0e38aa14f5",
+    "text": "অনেক কিছু নিয়ে ভয় পাই",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 1
+  },
+  {
+    "id": "9f9166f0-fa94-4c14-a91d-3eecd8395794",
+    "text": "অন্যদের সাথে যোগাযোগ এড়িয়ে চলি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 1
+  },
+  {
+    "id": "23a1034f-fab7-4887-a66e-5ef4eaafb25e",
+    "text": "দিবাস্বপ্ন দেখতে ভালোবাসি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 1
+  },
+  {
+    "id": "c63e6121-c3ed-40cc-abc2-c1e6ea1e0858",
+    "text": "মানুষ যা বলে তা বিশ্বাস করি",
+    "keyed": "plus",
+    "domain": "A",
+    "facet": 1
+  },
+  {
+    "id": "02ee1930-36a7-4caa-b10c-c93efb682a44",
+    "text": "কাজগুলো সাবলীলভাবে সামলাই",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 1
+  },
+  {
+    "id": "da8e6ed1-2296-4c58-8fdb-66f2f591989b",
+    "text": "মেজাজ হারিয়ে ফেলি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 2
+  },
+  {
+    "id": "03c10b30-b88f-4c63-8acc-71251ca24615",
+    "text": "একা থাকতে পছন্দ করি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 2
+  },
+  {
+    "id": "751a04bc-5adf-485a-8ea4-4308406ae85b",
+    "text": "কবিতা পছন্দ করি না",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 2
+  },
+  {
+    "id": "982e83c2-d34e-48da-9c71-78494ab05c85",
+    "text": "অন্যদের সুযোগ নিই",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 2
+  },
+  {
+    "id": "f4891687-0ff0-47af-a4f6-d1202c8f6676",
+    "text": "ঘর অগোছালো রাখি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 2
+  },
+  {
+    "id": "743d8973-1de1-4485-91b4-8a5cf63e7d44",
+    "text": "প্রায়ই মনমরা/হতাশাগ্রস্ত থাকি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 3
+  },
+  {
+    "id": "2452f034-8273-4f71-9122-a40f5ead31ba",
+    "text": "সবকিছুর নিয়ন্ত্রণ নিয়ে নিই",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 3
+  },
+  {
+    "id": "2a300001-6e05-4c79-b8b5-2ccae4c3d463",
+    "text": "খুব কমই আমার আবেগীয় প্রতিক্রিয়া লক্ষ্য করি",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 3
+  },
+  {
+    "id": "cd54bd76-ca9c-4030-b325-bb8d896bcb3f",
+    "text": "অন্যদের অনুভূতির প্রতি উদাসীন",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 3
+  },
+  {
+    "id": "4e6e3a34-176f-4e6e-8730-1341611f972b",
+    "text": "নিয়ম ভাঙি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 3
+  },
+  {
+    "id": "20062533-a33d-4c1e-9cd9-bff868015b3f",
+    "text": "শুধু বন্ধুদের সাথেই স্বাচ্ছন্দ্য বোধ করি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 4
+  },
+  {
+    "id": "b2a077d5-1fe0-4b06-ab63-35455e001e54",
+    "text": "অবসর সময়ে অনেক কিছু করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 4
+  },
+  {
+    "id": "0d2e65ab-95d9-482f-beb4-3239a3a4944a",
+    "text": "পরিবর্তন অপছন্দ করি",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 4
+  },
+  {
+    "id": "0de0f900-cede-4538-9c00-5da4f830b028",
+    "text": "মানুষকে অপমান করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 4
+  },
+  {
+    "id": "a9c97d6b-6721-4150-8d84-64ef3082f164",
+    "text": "শুধু চালিয়ে নেওয়ার মতো কাজ করি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 4
+  },
+  {
+    "id": "9f2e7f90-0ca5-4ed0-9fe5-e060238a9b5e",
+    "text": "সহজেই প্রলোভন প্রতিরোধ করতে পারি",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 5
+  },
+  {
+    "id": "7dd6cf2d-5c14-48c2-8ae5-633a7a596c71",
+    "text": "বেপরোয়া থাকা উপভোগ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 5
+  },
+  {
+    "id": "fecc35f7-681e-4889-a404-4a973a3dfef0",
+    "text": "বিমূর্ত ধারণা বুঝতে অসুবিধা হয়",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 5
+  },
+  {
+    "id": "1d686958-6fe7-432f-85e6-186b99e4e232",
+    "text": "নিজের সম্পর্কে উঁচু ধারণা রাখি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 5
+  },
+  {
+    "id": "c7db0ed8-df7d-49bf-942f-59e46ef743c4",
+    "text": "সময় নষ্ট করি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 5
+  },
+  {
+    "id": "b7e0e393-9b21-4e0d-adf3-8f28fb5b9d87",
+    "text": "মনে করি পরিস্থিতি সামলাতে অক্ষম",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 6
+  },
+  {
+    "id": "79d956e8-1118-402a-a0e2-9380af18243e",
+    "text": "জীবনকে ভালোবাসি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 6
+  },
+  {
+    "id": "96ba77b2-1a44-4dfd-95f9-ae4d1f714460",
+    "text": "সাধারণত রক্ষণশীল রাজনৈতিক প্রার্থীদের ভোট দিই",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 6
+  },
+  {
+    "id": "77f54ab4-0fba-4efb-8700-066c7490eb87",
+    "text": "অন্যদের সমস্যায় আগ্রহ নেই",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 6
+  },
+  {
+    "id": "a354cf7c-8d11-46ac-acc5-da90d2048637",
+    "text": "তাড়াহুড়ো করে কাজে নেমে পড়ি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 6
+  },
+  {
+    "id": "43b03992-3f32-4ed1-a6f8-5d6d3e7ed246",
+    "text": "সহজে মানসিক চাপে পড়ি",
+    "keyed": "plus",
+    "domain": "N",
+    "facet": 1
+  },
+  {
+    "id": "41702602-08e4-4e2b-9a19-291d9efc581a",
+    "text": "অন্যদের থেকে দূরত্ব বজায় রাখি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 1
+  },
+  {
+    "id": "935a7413-abac-4f54-9169-d1fbd39da752",
+    "text": "চিন্তায় হারিয়ে যেতে পছন্দ করি",
+    "keyed": "plus",
+    "domain": "O",
+    "facet": 1
+  },
+  {
+    "id": "432dbde8-8756-4ff0-80d5-f47018235139",
+    "text": "মানুষকে অবিশ্বাস করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 1
+  },
+  {
+    "id": "5727c93f-317b-4af1-a686-77fc9fbc5033",
+    "text": "কীভাবে কাজ সম্পন্ন করতে হয় তা জানি",
+    "keyed": "plus",
+    "domain": "C",
+    "facet": 1
+  },
+  {
+    "id": "d32bd062-4eb2-401b-99b2-e7afea39ca9b",
+    "text": "সহজে বিরক্ত হই না",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 2
+  },
+  {
+    "id": "9a47184f-6046-4e68-a61b-3d9b357b86ea",
+    "text": "ভিড় এড়িয়ে চলি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 2
+  },
+  {
+    "id": "87c5b27e-59a8-4c48-8ba8-f5413d735693",
+    "text": "আর্ট মিউজিয়ামে যেতে উপভোগ করি না",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 2
+  },
+  {
+    "id": "11b20adb-abed-4363-894c-3dd823ae0540",
+    "text": "অন্যদের পরিকল্পনায় বাধা দিই",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 2
+  },
+  {
+    "id": "50418d86-712c-45d9-adc4-ea0231c93cf5",
+    "text": "জিনিসপত্র যেখানে সেখানে ফেলে রাখি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 2
+  },
+  {
+    "id": "f40e421f-6c24-4be2-bd9f-28d33358d8c6",
+    "text": "নিজের সম্পর্কে স্বাচ্ছন্দ্য বোধ করি",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 3
+  },
+  {
+    "id": "8791f37b-686f-47c3-9db7-74c009951321",
+    "text": "অন্যদের নেতৃত্ব দেওয়ার জন্য অপেক্ষা করি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 3
+  },
+  {
+    "id": "4fd25155-9cc2-4cd6-8852-3e0ca2d5e95d",
+    "text": "যারা আবেগপ্রবণ হয়ে পড়ে তাদের বুঝি না",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 3
+  },
+  {
+    "id": "b68af20d-24f9-4c27-85cc-fe0858994888",
+    "text": "অন্যদের জন্য সময় বের করি না",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 3
+  },
+  {
+    "id": "54423933-0ebb-44a7-bdd9-2a9b100c70f2",
+    "text": "আমার প্রতিশ্রুতি ভঙ্গ করি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 3
+  },
+  {
+    "id": "7317848c-3e1b-422f-bb16-02efc504f677",
+    "text": "কঠিন সামাজিক পরিস্থিতিতে বিচলিত হই না",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 4
+  },
+  {
+    "id": "7d93e1ca-46e8-4a30-9623-42a80c9b420c",
+    "text": "নির্ভার/ধীরেসুস্থে চলতে পছন্দ করি",
+    "keyed": "minus",
+    "domain": "E",
+    "facet": 4
+  },
+  {
+    "id": "a7f43928-8982-4ed5-8656-7a80346fe979",
+    "text": "প্রচলিত রীতিনীতির প্রতি অনুরক্ত",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 4
+  },
+  {
+    "id": "17910a55-a64a-4ed0-8b46-293e2fa2fe03",
+    "text": "অন্যদের ওপর প্রতিশোধ নিই",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 4
+  },
+  {
+    "id": "3890bb43-2695-4b8d-b289-ee10d11cc884",
+    "text": "কাজে সামান্য সময় ও শ্রম দিই",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 4
+  },
+  {
+    "id": "49a85680-53aa-4208-86b5-dccc7a6f8e37",
+    "text": "আমার আকাঙ্ক্ষা/লোভ নিয়ন্ত্রণ করতে পারি",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 5
+  },
+  {
+    "id": "10f90fa9-649c-4631-ac4c-3dd3f751597d",
+    "text": "উদ্দাম ও পাগলাটে আচরণ করি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 5
+  },
+  {
+    "id": "b86de003-c3c4-4cc8-9385-5ac8a0142c34",
+    "text": "তাত্ত্বিক আলোচনায় আগ্রহ নেই",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 5
+  },
+  {
+    "id": "80c1d149-7050-481a-9953-aefb441642e7",
+    "text": "নিজের গুণাবলী নিয়ে গর্ব করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 5
+  },
+  {
+    "id": "51403620-968c-42fa-a772-65ba5ad8396f",
+    "text": "কাজ শুরু করতে অসুবিধা হয়",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 5
+  },
+  {
+    "id": "88a3c2fe-3aa4-4f46-9322-da656332268a",
+    "text": "চাপের মধ্যেও শান্ত থাকি",
+    "keyed": "minus",
+    "domain": "N",
+    "facet": 6
+  },
+  {
+    "id": "e7b31bdc-5f6b-40ec-ba91-f5919b0f170e",
+    "text": "জীবনের ভালো দিকটা দেখি",
+    "keyed": "plus",
+    "domain": "E",
+    "facet": 6
+  },
+  {
+    "id": "580b08d1-3c94-46e9-9d07-d6d80c698127",
+    "text": "মনে করি অপরাধের ব্যাপারে কঠোর হওয়া উচিত",
+    "keyed": "minus",
+    "domain": "O",
+    "facet": 6
+  },
+  {
+    "id": "48bee420-60c0-45cd-be43-3893dbc1969a",
+    "text": "অভাবীদের নিয়ে চিন্তা না করার চেষ্টা করি",
+    "keyed": "minus",
+    "domain": "A",
+    "facet": 6
+  },
+  {
+    "id": "ea3327ea-3529-4be4-8e2d-2174731ae4d7",
+    "text": "না ভেবে কাজ করি",
+    "keyed": "minus",
+    "domain": "C",
+    "facet": 6
+  }
+]

--- a/data/languages.json
+++ b/data/languages.json
@@ -126,5 +126,9 @@
   {
     "id": "ca",
     "text":"Catalan"
+  },
+  {
+    "id": "bn",
+    "text": "Bengali"
   }
 ]


### PR DESCRIPTION
## Bengali (bn) Translation

This PR adds Bengali translations for all 120 items of the IPIP-NEO-PI-R questionnaire.

### Changes:
- Added `data/bn/questions.json` with Bengali translations
- Added `data/bn/choices.js` with Bengali response options
- Updated `data/languages.json` to include "bn"

### Notes on Translation Approach:
- Translated for psychological construct accuracy rather than literal word-for-word
- Items like "Go on binges" (N5) → rendered as losing self-restraint to capture the impulsiveness facet
- Reverse-keyed items maintain their negation structure for scoring validity
- Political items (28, 88, 118) kept neutral without softening content

### Verification:
- `getItems('bn')` returns 120 items
- All IDs, domains, facets, and keyed flags match English original
- Passes `standard` lint and `ava` tests (`test-offline`)

### Note on CI:
The full `npm test` includes `npm audit`, which reports 24 pre-existing vulnerabilities in the repo's dev dependencies (ava, nyc, standard, etc.). These exist on the upstream `main` branch independently of this PR and are unrelated to this translation change.
